### PR TITLE
Allow booleans to be stored (as smallints)

### DIFF
--- a/src/main/java/liquibase/ext/hana/datatype/HanaBooleanType.java
+++ b/src/main/java/liquibase/ext/hana/datatype/HanaBooleanType.java
@@ -21,4 +21,9 @@ public class HanaBooleanType extends BooleanType {
     public DatabaseDataType toDatabaseDataType(Database database) {
         return new DatabaseDataType("SMALLINT");
     }
+    
+    @Override
+	protected boolean isNumericBoolean(Database database) {
+		return true;
+	}
 }


### PR DESCRIPTION
HANA doesn't have a built-in boolean type, that's why a smallint is used instead. 
IsNumericBoolean should return "true" in this case, to make sure that when a Boolean.FALSE is used, it is translated to 0 or 1.
